### PR TITLE
fixes impedance mistake in text

### DIFF
--- a/02_Linear_Systems.ipynb
+++ b/02_Linear_Systems.ipynb
@@ -378,7 +378,7 @@
     "* another alternative definition of the linear system:\n",
     "  - velocity input $\\vc$\n",
     "  - force output $\\Fc$\n",
-    "  - frequency response is the **impedance** (also: admittance):\n",
+    "  - frequency response is the **impedance**:\n",
     "\\begin{equation}\\label{eq:impedance_def}\n",
     "\\Zc=\\frac{\\Fc}{\\vc}\n",
     "\\end{equation}\n",
@@ -604,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
fixes mistake in section 02 test: mobility = admittance, impedance != admittance